### PR TITLE
Do not need to create your meta description

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html class="no-js" <?php language_attributes(); ?>>
 <head>
-  <meta name="description" content="<?php if ( is_single() ) {
-      single_post_title('', true);
-    } else {
-      bloginfo('name'); echo " - "; bloginfo('description');
-    }
-  ?>" />
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
The call to create the meta description causes duplicate meta descriptions when using Yoast SEO. The appropriate way would be to hook into wp_head. It would be best to exclude the meta description from the header.php file, and let a plugin hook into the wp_head action.