### PR TITLE
Remove resource suffix

### DIFF
--- a/functions/enqueues.php
+++ b/functions/enqueues.php
@@ -8,14 +8,14 @@ if ( ! function_exists('b4st_enqueues') ) {
 
 		// Styles
 
-		wp_register_style('bootstrap-css', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css', false, '4.1.3', null);
-		wp_enqueue_style('bootstrap-css');
+		wp_register_style('bootstrap', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css', false, '4.1.3', null);
+		wp_enqueue_style('bootstrap');
 
-		wp_register_style('fontawesome5-css', 'https://use.fontawesome.com/releases/v5.4.1/css/all.css', false, '5.4.1', null);
-		wp_enqueue_style('fontawesome5-css');
+		wp_register_style('fontawesome5', 'https://use.fontawesome.com/releases/v5.4.1/css/all.css', false, '5.4.1', null);
+		wp_enqueue_style('fontawesome5');
 
-		wp_register_style('b4st-css', get_template_directory_uri() . '/theme/css/b4st.css', false, null);
-		wp_enqueue_style('b4st-css');
+		wp_register_style('b4st', get_template_directory_uri() . '/theme/css/b4st.css', false, null);
+		wp_enqueue_style('b4st');
 
 		// Scripts
 
@@ -27,11 +27,11 @@ if ( ! function_exists('b4st_enqueues') ) {
 		wp_register_script('popper',  'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js', false, '1.14.3', true);
 		wp_enqueue_script('popper');
 
-		wp_register_script('bootstrap-js', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js', false, '4.1.3', true);
-		wp_enqueue_script('bootstrap-js');
+		wp_register_script('bootstrap', 'https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js', false, '4.1.3', true);
+		wp_enqueue_script('bootstrap');
 
-		wp_register_script('b4st-js', get_template_directory_uri() . '/theme/js/b4st.js', false, null, true);
-		wp_enqueue_script('b4st-js');
+		wp_register_script('b4st', get_template_directory_uri() . '/theme/js/b4st.js', false, null, true);
+		wp_enqueue_script('b4st');
 
 		if (is_singular() && comments_open() && get_option('thread_comments')) {
 			wp_enqueue_script('comment-reply');


### PR DESCRIPTION
In wordpress a function `wp_register_style` creates its own suffix for the indentifier, so currently we're seeing an extra duplicate in the page source code. I have removed from `wp_register_script` function as well, because there's no need for a suffix since it's already unique by default.

**Current Output:**

<img width="381" alt="b4st-wordpress" src="https://user-images.githubusercontent.com/8487654/49600337-a2173380-f98b-11e8-88f5-e12940429e8a.png">